### PR TITLE
fix bug in hash_icrc_value

### DIFF
--- a/src/icrc7/src/utils.rs
+++ b/src/icrc7/src/utils.rs
@@ -42,7 +42,8 @@ pub fn hash_icrc_value(value: &Value) -> generic_value::Hash {
     let hash = hasher.finish();
 
     let mut result = [0; 32];
-    result.copy_from_slice(&hash.to_le_bytes());
+    let hash = hash.to_le_bytes();
+    result[..hash.len()].copy_from_slice(&hash);
     result
 }
 


### PR DESCRIPTION
fix bug where copy_from_slice could have not copied a slice of length 8 in a slice of length 32

Error: " [Canister bw4dl-smaaa-aaaaa-qaacq-cai] Panicked at 'source slice length (8) does not match destination slice length (32)', src/icrc7/src/utils.rs:45:12 "